### PR TITLE
add read only db user

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -181,6 +181,15 @@ madek_graphql_api_service_name: "{{madek_base_name}}_api"
 madek_user_docs_dir: "{{madek_root_dir}}/user-docs"
 madek_user_docs_web_path: "/hilfe"
 
+# database
+database:
+  user: "{{madek_user}}"
+  password: "{{madek_database_secret}}"
+  hostname: localhost
+  port: 5432
+  name: "{{madek_base_name}}_production"
+  pool: 5 # should be (service.max_threads_per_worker - 1)
+
 madek_services:
   # NOTE: the name of the keys matter for sorting;
   # webapp must be the last in pythons default sorting
@@ -210,6 +219,9 @@ madek_services:
     assets_sub_dir: /public/assets
     http_port: "{{madek_graphql_api_port}}"
     context: "/graphql"
+    database:
+      user: "{{database.user}}-readonly"
+      password: "{{database.password}}-readonly"
     xmx: 512m
     monit_match: 'puma.*\:{{madek_graphql_api_port}}'
     monit_check_urls:
@@ -225,6 +237,7 @@ madek_services:
     assets_sub_dir: /public/admin/assets
     http_port: "{{madek_admin_port}}"
     context: "/admin"
+    database: { user: "{{database.user}}", password: "{{database.password}}" }
     xmx: 512m
     monit_match: 'puma.*\:{{madek_admin_port}}'
     monit_check_urls:
@@ -239,18 +252,10 @@ madek_services:
     max_workers: "{{ansible_processor_vcpus}}"
     max_threads_per_worker: 4
     dir: /webapp
+    database: { user: "{{database.user}}", password: "{{database.password}}" }
     assets_sub_dir: /public/assets
     http_port: "{{madek_webapp_port}}"
     context: ""
     monit_match: 'puma.*\:{{madek_webapp_port}}'
     monit_check_urls:
       - http://localhost:{{madek_webapp_port}}/status
-
-# database
-database:
-  user: "{{madek_user}}"
-  password: "{{madek_database_secret}}"
-  hostname: localhost
-  port: 5432
-  name: "{{madek_base_name}}_production"
-  pool: 5 # should be (service.max_threads_per_worker - 1)

--- a/inventories/zhdk/host_vars/test-blank.yml
+++ b/inventories/zhdk/host_vars/test-blank.yml
@@ -30,7 +30,7 @@ db_backups_enabled: False
 # db_backups_dir: /opt/madekdata/backups
 restore_structure_and_data: no
 madek_feature_toggle_admin_sql_reports: "on my own risk"
-madek_graphql_api_preview_enabled: false
+madek_graphql_api_preview_enabled: true
 
 ###############################################################################
 ### file storage ##############################################################

--- a/roles/madek-configuration/templates/database.yml
+++ b/roles/madek-configuration/templates/database.yml
@@ -6,5 +6,5 @@
   port: {{database.port}}
   pool: 20
   host: 127.0.0.1
-  username: '{{database.user}}'
-  password: '{{database.password}}'
+  username: '{{service.database.user}}'
+  password: '{{service.database.password}}'

--- a/roles/madek-datalayer/tasks/main.yml
+++ b/roles/madek-datalayer/tasks/main.yml
@@ -120,3 +120,33 @@
 #     group: root
 #     state: directory
 #     recurse: yes
+
+- name: check for read-only postgresql role
+  args: { warn: no }
+  changed_when: false
+  register: check_readonly_postgresql_role
+  shell: sudo -iu postgres psql -c "SELECT 'already exists' FROM pg_catalog.pg_roles WHERE rolname = 'madek_role_readonly'"
+
+- name: add read-only postgresql role
+  args: { warn: no }
+  when: '"already exists" not in check_readonly_postgresql_role.stdout'
+  shell: sudo -iu postgres psql -c "CREATE ROLE madek_role_readonly NOLOGIN;"
+
+- name: check for read-only postgresql user
+  args: { warn: no }
+  changed_when: false
+  register: check_readonly_postgresql_user
+  shell: sudo -iu postgres psql -c "SELECT 'already exists' FROM pg_catalog.pg_roles WHERE rolname = '{{database.user}}-readonly'"
+
+- name: add read-only postgresql user
+  args: { warn: no }
+  when: '"already exists" not in check_readonly_postgresql_user.stdout'
+  shell: sudo -iu postgres psql -c "CREATE ROLE \"{{database.user}}-readonly\" LOGIN;"
+
+- name: configure privileges read-only postgresql user
+  args: { warn: no }
+  shell: >
+    sudo -iu postgres psql -d '{{database.name}}' -c '
+      GRANT SELECT ON ALL TABLES IN SCHEMA public TO "madek-readonly";
+      GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO "madek-readonly";
+      GRANT "madek_role_readonly" TO "{{database.user}}-readonly";'


### PR DESCRIPTION
background: for services that only need to read data, we want a second database user with only read permissions. "SQL Reports" could use it (if extracted from admin app) as well as the "GraphQL API" (which atm will only be deployed to `test` servers, so prod DB is not affected in any case).

i used the following docs: 
+ https://blog.redash.io/postgres-readonly/
+ https://www.postgresql.org/docs/current/sql-grant.html

@DrTom please review that the code does what i think ;) 

- add a "group-like" role `madek_role_readonly`, can only read from the DB
- add a "user-like" role `madek-readonly`, is part of the `madek_role_readonly`
  - there can be 1 such user per service once we need that.
  - the user does not have its own "secure" password, because i want to protect against bugs in our code, not malicous users on the server etc.